### PR TITLE
Add UPnP fallback discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ reqwest = { version = "0.10", features = [ "blocking", "json" ]}
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
+ssdp-probe = "0.1"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/kali/hue.rs.svg?branch=master)](https://travis-ci.org/kali/hue.rs)
 
 ## Features
- - discover bridge by querying philips hue website (upnp not implemented)
+ - discover bridge by querying philips hue website or using UPnP
  - list lights with their state
  - simple actions on lights (on, off, bri/hue/sat, transition time)
  - simple CLI utils for docs and tests :)

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -135,8 +135,8 @@ impl Bridge {
 
     #[allow(dead_code)]
     pub fn discover() -> Option<Bridge> {
-        disco::discover_hue_bridge().ok().map(|i| Bridge {
-            ip: i.parse().unwrap(),
+        disco::discover_hue_bridge().ok().map(|ip| Bridge {
+            ip,
             username: None,
             client: reqwest::blocking::Client::new(),
         })

--- a/src/disco.rs
+++ b/src/disco.rs
@@ -1,8 +1,19 @@
-use crate::*;
 use reqwest;
 use serde_json::*;
+use std::net::IpAddr;
 
-pub fn discover_hue_bridge() -> HueResult<String> {
+use crate::*;
+
+pub fn discover_hue_bridge() -> HueResult<IpAddr> {
+    let n_upnp_result = discover_hue_bridge_n_upnp();
+    if n_upnp_result.is_err() {
+        discover_hue_bridge_upnp()
+    } else {
+        n_upnp_result
+    }
+}
+
+pub fn discover_hue_bridge_n_upnp() -> HueResult<IpAddr> {
     let objects: Vec<Map<String, Value>> =
         reqwest::blocking::get("https://discovery.meethue.com/")?.json()?;
 
@@ -17,5 +28,16 @@ pub fn discover_hue_bridge() -> HueResult<String> {
     Ok(ip
         .as_str()
         .ok_or("expect a string in internalipaddress")?
-        .to_string())
+        .parse()?)
+}
+
+pub fn discover_hue_bridge_upnp() -> HueResult<IpAddr> {
+    // use 'IpBridge' as a marker and a max duration of 5s as per
+    // https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery/
+    Ok(
+        ssdp_probe::ssdp_probe_v4(br"IpBridge", 1, std::time::Duration::from_secs(5))?
+            .first()
+            .map(|it| it.to_owned().into())
+            .ok_or("could not find bridge")?,
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ error_chain! {
     foreign_links {
         Reqwest(reqwest::Error);
         SerdeJson(serde_json::Error);
+        AddrParse(std::net::AddrParseError);
+        SSDP(ssdp_probe::SsdpProbeError);
     }
 
     errors {
@@ -19,5 +21,5 @@ error_chain! {
     }
 }
 
-mod disco;
 pub mod bridge;
+mod disco;


### PR DESCRIPTION
The current method to discover the Hue bridge is to use N-UPnP which is fine in most cases but depends on an internet connection being available both for the client and the bridge

This PR adds support for a fallback UPnP method that will work even no internet connection is available (is both devices are on the same network of course)

Implementation pointers regarding how to filter SSPD responses were found [here](https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery/)