### PR TITLE
change light state to handle optional fields

### DIFF
--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -18,16 +18,12 @@ fn main() {
                     l.id,
                     l.light.name,
                     if l.light.state.on { "on" } else { "off" },
-                    l.light.state.bri,
-                    l.light.state.hue,
-                    l.light.state.sat,
-                    l.light
-                        .state
-                        .ct
-                        .map(|k| if k != 0 { 1000000u32 / (k as u32) } else { 0 })
-                        .unwrap_or(0),
-                    l.light.state.xy.unwrap().0,
-                    l.light.state.xy.unwrap().1,
+                    if l.light.state.bri.is_some() {l.light.state.bri.unwrap()} else {0},
+                    if l.light.state.hue.is_some() {l.light.state.hue.unwrap()} else {0},
+                    if l.light.state.sat.is_some() {l.light.state.sat.unwrap()} else {0},
+                    if l.light.state.ct.is_some() {l.light.state.ct.map(|k| if k != 0 { 1000000u32 / (k as u32) } else { 0 }).unwrap()} else {0},
+                    if l.light.state.xy.is_some() {l.light.state.xy.unwrap().0} else {0.0},
+                    if l.light.state.xy.is_some() {l.light.state.xy.unwrap().1} else {0.0},
                 );
             }
         }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -9,9 +9,9 @@ use crate::*;
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct LightState {
     pub on: bool,
-    pub bri: u8,
-    pub hue: u16,
-    pub sat: u8,
+    pub bri: Option<u8>,
+    pub hue: Option<u16>,
+    pub sat: Option<u8>,
     pub ct: Option<u16>,
     pub xy: Option<(f32, f32)>,
 }


### PR DESCRIPTION
make fields optional as not all product support them, i.e. :

```
"productname": "Hue ambiance candle",
    "state": {
      "on": false,
      "bri": 254,
      "ct": 367,
      "alert": "select",
      "colormode": "ct",
      "mode": "homeautomation",
      "reachable": false
    },
```

```
"productname": "Hue white lamp",
    "state": {
      "on": false,
      "bri": 254,
      "alert": "select",
      "mode": "homeautomation",
      "reachable": true
    },
```