### PR TITLE
Use rustls instead of openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 error-chain="0.12"
 regex = "1.3"
-reqwest = { version = "0.10", features = [ "blocking", "json" ]}
+reqwest = { version = "0.10", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
 serde = "1"
 serde_json = "1"
 serde_derive = "1"


### PR DESCRIPTION
this change is transparent for the lib and makes it easier to cross compile on exotic targets