### PR TITLE
Update SSDP probe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ reqwest = { version = "0.10", features = [ "blocking", "json" ]}
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-ssdp-probe = "0.1"
+ssdp-probe = "0.2"


### PR DESCRIPTION
use the lastest version of SSDP probe, that will not fail if the standard SSDP port is already bound on the device