### PR TITLE
Modernize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 error-chain="0.12"
 regex = "1.3"
 reqwest = { version = "0.10", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
-serde = "1"
+serde = { version = "1", features = ["derive"]}
 serde_json = "1"
-serde_derive = "1"
 ssdp-probe = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [ "Philips", "hue", "light", "bulb" ]
 edition = "2018"
 
 [dependencies]
-error-chain="0.12"
+thiserror = "1.0.20"
 regex = "1.3"
 reqwest = { version = "0.10", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
 serde = { version = "1", features = ["derive"]}

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -1,4 +1,5 @@
 extern crate hueclient;
+use hueclient::HueError;
 use std::env;
 
 #[allow(while_true)]
@@ -18,8 +19,7 @@ fn main() {
                     println!("{}", r);
                     break;
                 }
-                Err(hueclient::HueError(hueclient::HueErrorKind::BridgeError(code, _), _))
-                    if code == 101 => {
+                Err(HueError::BridgeError { code, .. }) if code == 101 => {
                     println!("Push the bridge button");
                     std::thread::sleep(::std::time::Duration::from_secs(5));
                 }

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -9,7 +9,7 @@ fn main() {
     if args.len() != 2 {
         println!("usage : {:?} <devicetype>", args[0]);
     } else {
-        let bridge = ::hueclient::bridge::Bridge::discover_required();
+        let mut bridge = ::hueclient::bridge::Bridge::discover_required();
         println!("posting user {:?} in {:?}", args[1], bridge);
         while true {
             let r = bridge.register_user(&args[1]);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -154,7 +154,7 @@ impl Bridge {
         }
     }
 
-    pub fn register_user(&self, devicetype: &str) -> HueResult<String> {
+    pub fn register_user(&self, devicetype: &str) -> Result<String, HueError> {
         #[derive(Serialize, Deserialize)]
         struct PostApi {
             devicetype: String,
@@ -176,7 +176,7 @@ impl Bridge {
         Ok(success.success.username)
     }
 
-    pub fn get_all_lights(&self) -> HueResult<Vec<IdentifiedLight>> {
+    pub fn get_all_lights(&self) -> Result<Vec<IdentifiedLight>, HueError> {
         let url = format!(
             "http://{}/api/{}/lights",
             self.ip,
@@ -185,16 +185,16 @@ impl Bridge {
         let resp: HashMap<String, Light> = self.parse(self.client.get(&url[..]).send()?.json()?)?;
         let mut lights = vec![];
         for (k, v) in resp {
-            let id: usize = usize::from_str(&k).or(Err(HueErrorKind::ProtocolError(
-                "Light id should be a number".to_string(),
-            )))?;
+            let id: usize = usize::from_str(&k).or(Err(HueError::ProtocolError {
+                msg: "Light id should be a number".to_string(),
+            }))?;
             lights.push(IdentifiedLight { id, light: v });
         }
         lights.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(lights)
     }
 
-    pub fn set_light_state(&self, light: usize, command: &CommandLight) -> HueResult<Value> {
+    pub fn set_light_state(&self, light: usize, command: &CommandLight) -> Result<Value, HueError> {
         let url = format!(
             "http://{}/api/{}/lights/{}/state",
             self.ip,
@@ -211,22 +211,22 @@ impl Bridge {
         self.parse(resp)
     }
 
-    fn parse<T: ::serde::de::DeserializeOwned>(&self, value: Value) -> HueResult<T> {
+    fn parse<T: ::serde::de::DeserializeOwned>(&self, value: Value) -> Result<T, HueError> {
         use serde_json::*;
         if !value.is_array() {
             return Ok(from_value(value)?);
         }
         let mut objects: Vec<Value> = from_value(value)?;
         if objects.len() == 0 {
-            Err(HueErrorKind::ProtocolError(
-                "expected non-empty array".to_string(),
-            ))?
+            Err(HueError::ProtocolError {
+                msg: "expected non-empty array".to_string(),
+            })?
         }
         let value = objects.remove(0);
         {
-            let object = value.as_object().ok_or(HueErrorKind::ProtocolError(
-                "expected first item to be an object".to_string(),
-            ))?;
+            let object = value.as_object().ok_or(HueError::ProtocolError {
+                msg: "expected first item to be an object".to_string(),
+            })?;
             if let Some(e) = object.get("error").and_then(|o| o.as_object()) {
                 let code: u64 = e.get("type").and_then(|s| s.as_u64()).unwrap_or(0);
                 let desc = e
@@ -234,7 +234,10 @@ impl Bridge {
                     .and_then(|s| s.as_str())
                     .unwrap_or("")
                     .to_string();
-                Err(HueErrorKind::BridgeError(code as usize, desc))?
+                Err(HueError::BridgeError {
+                    code: code as usize,
+                    msg: desc,
+                })?
             }
         }
         Ok(from_value(value)?)

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -120,8 +120,8 @@ impl CommandLight {
 
 #[derive(Debug)]
 pub struct Bridge {
-    ip: std::net::IpAddr,
-    username: Option<String>,
+    pub ip: std::net::IpAddr,
+    pub username: Option<String>,
     client: reqwest::blocking::Client,
 }
 
@@ -154,7 +154,7 @@ impl Bridge {
         }
     }
 
-    pub fn register_user(&self, devicetype: &str) -> Result<String, HueError> {
+    pub fn register_user(&mut self, devicetype: &str) -> Result<String, HueError> {
         #[derive(Serialize, Deserialize)]
         struct PostApi {
             devicetype: String,
@@ -173,6 +173,9 @@ impl Bridge {
         let url = format!("http://{}/api", self.ip);
         let success: Success =
             self.parse(self.client.post(&url[..]).json(&obtain).send()?.json()?)?;
+
+        self.username = Some(success.success.username.clone());
+
         Ok(success.success.username)
     }
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use reqwest;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::*;
@@ -187,7 +188,7 @@ impl Bridge {
             let id: usize = usize::from_str(&k).or(Err(HueErrorKind::ProtocolError(
                 "Light id should be a number".to_string(),
             )))?;
-            lights.push(IdentifiedLight { id: id, light: v });
+            lights.push(IdentifiedLight { id, light: v });
         }
         lights.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(lights)

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -180,7 +180,7 @@ impl Bridge {
         let url = format!(
             "http://{}/api/{}/lights",
             self.ip,
-            self.username.clone().unwrap()
+            self.username.as_ref().ok_or(HueError::NoUsername)?
         );
         let resp: HashMap<String, Light> = self.parse(self.client.get(&url[..]).send()?.json()?)?;
         let mut lights = vec![];
@@ -198,7 +198,7 @@ impl Bridge {
         let url = format!(
             "http://{}/api/{}/lights/{}/state",
             self.ip,
-            self.username.clone().unwrap(),
+            self.username.as_ref().ok_or(HueError::NoUsername)?,
             light
         );
         let body = ::serde_json::to_vec(command)?;

--- a/src/disco.rs
+++ b/src/disco.rs
@@ -1,10 +1,9 @@
+use crate::{HueError, HueError::DiscoveryError};
 use reqwest;
-use serde_json::*;
+use serde_json::{Map, Value};
 use std::net::IpAddr;
 
-use crate::*;
-
-pub fn discover_hue_bridge() -> HueResult<IpAddr> {
+pub fn discover_hue_bridge() -> Result<IpAddr, HueError> {
     let n_upnp_result = discover_hue_bridge_n_upnp();
     if n_upnp_result.is_err() {
         discover_hue_bridge_upnp()
@@ -13,31 +12,37 @@ pub fn discover_hue_bridge() -> HueResult<IpAddr> {
     }
 }
 
-pub fn discover_hue_bridge_n_upnp() -> HueResult<IpAddr> {
+pub fn discover_hue_bridge_n_upnp() -> Result<IpAddr, HueError> {
     let objects: Vec<Map<String, Value>> =
         reqwest::blocking::get("https://discovery.meethue.com/")?.json()?;
 
     if objects.len() == 0 {
-        Err("expected non-empty array")?
+        Err(DiscoveryError {
+            msg: "expected non-empty array".into(),
+        })?
     }
     let ref object = objects[0];
 
-    let ip = object
-        .get("internalipaddress")
-        .ok_or("Expected internalipaddress")?;
+    let ip = object.get("internalipaddress").ok_or(DiscoveryError {
+        msg: "Expected internalipaddress".into(),
+    })?;
     Ok(ip
         .as_str()
-        .ok_or("expect a string in internalipaddress")?
+        .ok_or(DiscoveryError {
+            msg: "expect a string in internalipaddress".into(),
+        })?
         .parse()?)
 }
 
-pub fn discover_hue_bridge_upnp() -> HueResult<IpAddr> {
+pub fn discover_hue_bridge_upnp() -> Result<IpAddr, HueError> {
     // use 'IpBridge' as a marker and a max duration of 5s as per
     // https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery/
     Ok(
         ssdp_probe::ssdp_probe_v4(br"IpBridge", 1, std::time::Duration::from_secs(5))?
             .first()
             .map(|it| it.to_owned().into())
-            .ok_or("could not find bridge")?,
+            .ok_or(DiscoveryError {
+                msg: "could not find bridge".into(),
+            })?,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,21 @@
-error_chain::error_chain! {
-    types  { HueError, HueErrorKind, HueResultExt, HueResult; }
-    foreign_links {
-        Reqwest(reqwest::Error);
-        SerdeJson(serde_json::Error);
-        AddrParse(std::net::AddrParseError);
-        SSDP(ssdp_probe::SsdpProbeError);
-    }
+use thiserror::Error;
 
-    errors {
-        ProtocolError(msg: String)
-        BridgeError(code: usize, msg: String)
-    }
+#[derive(Error, Debug)]
+pub enum HueError {
+    #[error("An error occurred while performing an HTTP request")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("An error occurred while manipulating JSON")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("An error occurred while parsing an address")]
+    AddrParse(#[from] std::net::AddrParseError),
+    #[error("An error occurred during SSDP discovery")]
+    SSDP(#[from] ssdp_probe::SsdpProbeError),
+    #[error("A protocol error occurred: {}", msg)]
+    ProtocolError { msg: String },
+    #[error("The bridge reported error code {}: {}", code, msg)]
+    BridgeError { code: usize, msg: String },
+    #[error("A discovery error occurred: {}", msg)]
+    DiscoveryError { msg: String },
 }
 
 pub mod bridge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,4 @@
-#[macro_use]
-extern crate error_chain;
-extern crate serde;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-extern crate reqwest;
-
-error_chain! {
+error_chain::error_chain! {
     types  { HueError, HueErrorKind, HueResultExt, HueResult; }
     foreign_links {
         Reqwest(reqwest::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub enum HueError {
     BridgeError { code: usize, msg: String },
     #[error("A discovery error occurred: {}", msg)]
     DiscoveryError { msg: String },
+    #[error("This action requires an username to be registered")]
+    NoUsername,
 }
 
 pub mod bridge;


### PR DESCRIPTION
This pull request contains a batch of changes aimed to modernize a bit the codebase
- [x] remove useless `extern crate` statements
- [x] use `thiserror` instead of `error_chain`
- [x] removed some unwraps when trying to use a method requesting an username
- [x] made `username` and `ip` fields public on the `Bridge` (useful if you wanna persist them)
- [x] the `register` method on Bridge now takes a `&mut self` instead of a `&self` and update the username in the struct, meaning you can now use the bridge directly after the register without a need for recreating one with the username