### PR TITLE
Add UnauthBridge

### DIFF
--- a/src/bin/hue_discover_bridge.rs
+++ b/src/bin/hue_discover_bridge.rs
@@ -1,5 +1,5 @@
 extern crate hueclient;
-use hueclient::bridge::Bridge;
+use hueclient::Bridge;
 
 #[allow(dead_code)]
 fn main() {

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -8,7 +8,7 @@ fn main() {
         println!("usage : {:?} <username>", args[0]);
         return;
     }
-    let bridge = ::hueclient::bridge::Bridge::discover_required().with_user(args[1].to_string());
+    let bridge = ::hueclient::Bridge::discover_required().with_user(args[1].to_string());
     match bridge.get_all_lights() {
         Ok(lights) => {
             println!("id name                 on    bri   hue sat temp  x      y");

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -8,7 +8,7 @@ fn main() {
         println!("usage : {:?} <username>", args[0]);
         return;
     }
-    let bridge = ::hueclient::Bridge::discover_required().with_user(args[1].to_string());
+    let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     match bridge.get_all_lights() {
         Ok(lights) => {
             println!("id name                 on    bri   hue sat temp  x      y");

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -9,7 +9,7 @@ fn main() {
     if args.len() != 2 {
         println!("usage : {:?} <devicetype>", args[0]);
     } else {
-        let bridge = ::hueclient::Bridge::discover_required();
+        let bridge = hueclient::Bridge::discover_required();
         println!("posting user {:?} in {:?}", args[1], bridge);
         loop {
             let r = bridge.clone().register_user(&args[1]);

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -9,14 +9,14 @@ fn main() {
     if args.len() != 2 {
         println!("usage : {:?} <devicetype>", args[0]);
     } else {
-        let mut bridge = ::hueclient::bridge::Bridge::discover_required();
+        let bridge = ::hueclient::Bridge::discover_required();
         println!("posting user {:?} in {:?}", args[1], bridge);
-        while true {
-            let r = bridge.register_user(&args[1]);
+        loop {
+            let r = bridge.clone().register_user(&args[1]);
             match r {
                 Ok(r) => {
                     eprint!("done: ");
-                    println!("{}", r);
+                    println!("{}", r.username);
                     break;
                 }
                 Err(HueError::BridgeError { code, .. }) if code == 101 => {

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -14,7 +14,7 @@ fn main() {
         );
         return;
     }
-    let bridge = ::hueclient::bridge::Bridge::discover_required().with_user(args[1].to_string());
+    let bridge = ::hueclient::Bridge::discover_required().with_user(args[1].to_string());
     let ref lights: Vec<usize> = args[2]
         .split(",")
         .map(|s| s.parse::<usize>().unwrap())
@@ -27,11 +27,11 @@ fn main() {
     let re_xy = Regex::new("(0\\.[0-9]+),(0\\.[0-9]+)(:([0-9]{0,5}))?").unwrap();
     let re_rrggbb = Regex::new("([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})").unwrap();
     let mut parsed = match &command[..] {
-        "on" => hueclient::bridge::CommandLight::default().on(),
-        "off" => hueclient::bridge::CommandLight::default().off(),
+        "on" => hueclient::CommandLight::default().on(),
+        "off" => hueclient::CommandLight::default().off(),
         _ if re_triplet.is_match(&command) => {
             let caps = re_triplet.captures(&command).unwrap();
-            let mut command = hueclient::bridge::CommandLight::default().on();
+            let mut command = hueclient::CommandLight::default().on();
             command.bri = caps.get(1).and_then(|s| s.as_str().parse::<u8>().ok());
             command.hue = caps.get(2).and_then(|s| s.as_str().parse::<u16>().ok());
             command.sat = caps.get(3).and_then(|s| s.as_str().parse::<u8>().ok());
@@ -39,7 +39,7 @@ fn main() {
         }
         _ if re_mired.is_match(&command) => {
             let caps = re_mired.captures(&command).unwrap();
-            let mut command = hueclient::bridge::CommandLight::default().on();
+            let mut command = hueclient::CommandLight::default().on();
             command.ct = caps.get(1).and_then(|s| s.as_str().parse::<u16>().ok());
             command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
             command.sat = Some(254);
@@ -47,7 +47,7 @@ fn main() {
         }
         _ if re_kelvin.is_match(&command) => {
             let caps = re_kelvin.captures(&command).unwrap();
-            let mut command = hueclient::bridge::CommandLight::default().on();
+            let mut command = hueclient::CommandLight::default().on();
             command.ct = caps.get(1).and_then(|s| {
                 s.as_str().parse::<u32>().ok().map(
                     |k| (1000000u32 / k) as u16,
@@ -59,7 +59,7 @@ fn main() {
         }
         _ if re_rrggbb.is_match(&command) => {
             let caps = re_rrggbb.captures(&command).unwrap();
-            let mut command = hueclient::bridge::CommandLight::default().on();
+            let mut command = hueclient::CommandLight::default().on();
             let rgb: Vec<u8> = [caps.get(1), caps.get(2), caps.get(3)]
                 .iter()
                 .map(|s| u8::from_str_radix(s.unwrap().as_str(), 16).unwrap())
@@ -74,7 +74,7 @@ fn main() {
         _ if re_xy.is_match(&command) => {
             let caps = re_xy.captures(&command).unwrap();
             dbg!(&caps);
-            let mut command = hueclient::bridge::CommandLight::default().on();
+            let mut command = hueclient::CommandLight::default().on();
             let x = caps.get(1).unwrap().as_str().parse::<f32>().unwrap();
             let y = caps.get(2).unwrap().as_str().parse::<f32>().unwrap();
             command.xy = Some((x,y));

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -14,7 +14,7 @@ fn main() {
         );
         return;
     }
-    let bridge = ::hueclient::Bridge::discover_required().with_user(args[1].to_string());
+    let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     let ref lights: Vec<usize> = args[2]
         .split(",")
         .map(|s| s.parse::<usize>().unwrap())

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -189,7 +189,7 @@ impl Bridge {
     /// ```rust
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4]);
     /// ```
-    pub fn for_ip(ip: impl std::net::ToSocketAddrs) -> UnauthBridge {
+    pub fn for_ip(ip: impl Into<std::net::IpAddr>) -> UnauthBridge {
         UnauthBridge {
             ip: ip.into(),
             client: reqwest::blocking::Client::new(),

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-
-use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -125,11 +123,11 @@ pub struct UnauthBridge {
 }
 
 impl UnauthBridge {
-    /// Consumes the bidge and return a new one with a configured username.
+    /// Consumes the bridge and returns a new one with a configured username.
     /// ### Example
     /// ```rust
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
-    ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
+    ///     .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
     /// ```
     pub fn with_user(self, username: impl Into<String>) -> Bridge {
         Bridge {
@@ -191,7 +189,7 @@ impl Bridge {
     /// ```rust
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4]);
     /// ```
-    pub fn for_ip(ip: impl Into<std::net::IpAddr>) -> UnauthBridge {
+    pub fn for_ip(ip: impl std::net::ToSocketAddrs) -> UnauthBridge {
         UnauthBridge {
             ip: ip.into(),
             client: reqwest::blocking::Client::new(),

--- a/src/disco.rs
+++ b/src/disco.rs
@@ -1,5 +1,4 @@
 use crate::{HueError, HueError::DiscoveryError};
-use reqwest;
 use serde_json::{Map, Value};
 use std::net::IpAddr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,81 @@
-use thiserror::Error;
+//! This library aims to enable communicating with _Philips Hue_ lights via the correspnding Bridge.
+//!
+//! # Examples
+//! A short overview of the most common use cases of this library.
+//! ### Initial Setup
+//! ```rust
+//! let bridge = hueclient::Bridge::discover_required()
+//!     .register_user("mycomputer") // Press the bridge before running this
+//!     .unwrap();
+//! println!("the username was {}", bridge.username); // handy for later
+//! ```
+//! ### Second run
+//! ```rust
+//! const USERNAME: &str = "the username that was generated in the previous example";
+//! let bridge = hueclient::Bridge::discover_required()
+//!    .with_user(USERNAME);
+//! ```
+//! ### Good night
+//! ```rust
+//! # const USERNAME: &str = "the username that was generated in the previous example";
+//! # let bridge = hueclient::Bridge::discover_required()
+//! #   .with_user(USERNAME);
+//! let cmd = hueclient::light::LightCommand::new().off();
+//! for light in &bridge.lights().unwrap() {
+//!     bridge.set_light_state(light.id, &cmd).unwrap();
+//! }
+//! ```
 
-#[derive(Error, Debug)]
+/// Represents any of the ways that usage of this library may fail.
+#[derive(thiserror::Error, Debug)]
 pub enum HueError {
+    /// Returned when a network error occurs.
     #[error("An error occurred while performing an HTTP request")]
     Reqwest(#[from] reqwest::Error),
+    /// Returned on a JSON failure, which will usually be a problem with deserializing the bridge
+    /// response.
     #[error("An error occurred while manipulating JSON")]
     SerdeJson(#[from] serde_json::Error),
+    /// Returned when discovery.meethue.com returns an invalid IP-address.
     #[error("An error occurred while parsing an address")]
     AddrParse(#[from] std::net::AddrParseError),
+    /// Returned when the SSDP probe fails to scan the current network for a bridge.
     #[error("An error occurred during SSDP discovery")]
     SSDP(#[from] ssdp_probe::SsdpProbeError),
+    /// Returned when the Bridge returns a response that does not confirm to the API spec.
     #[error("A protocol error occurred: {}", msg)]
-    ProtocolError { msg: String },
+    ProtocolError {
+        /// An error message describing the failure.
+        msg: String,
+    },
+    /// Returned when the Bridge returns an error response
     #[error("The bridge reported error code {}: {}", code, msg)]
-    BridgeError { code: usize, msg: String },
+    BridgeError {
+        /// The error code.
+        code: usize,
+        /// An error message describing the failure.
+        msg: String,
+    },
+    /// Returned when discovering a bridge in the local network fails.
     #[error("A discovery error occurred: {}", msg)]
-    DiscoveryError { msg: String },
-    #[error("This action requires an username to be registered")]
-    NoUsername,
+    DiscoveryError {
+        /// An error message describing the failure.
+        msg: String,
+    },
 }
 
-pub mod bridge;
+impl HueError {
+    pub(crate) fn protocol_err(err: impl std::fmt::Display) -> Self {
+        Self::ProtocolError {
+            msg: err.to_string(),
+        }
+    }
+}
+
+/// A type alias used for convenience and consiceness throughout the library.
+pub type Result<T> = std::result::Result<T, HueError>;
+
+mod bridge;
 mod disco;
+
+pub use bridge::*;


### PR DESCRIPTION
This PR adds a struct to the API called `UnauthBridge`, which is a `Bridge` that has not been connected to the physical bridge yet. I opted to have the user construct this through `Bridge::for_ip` and `Bridge::discover` rather than through functions on `UnauthBridge`, to keep the `Bridge` struct the central point of attention. `Bridge::discover().with_user("hello")` also feels more intuitive than `UnauthBridge::discover().with_user("hello")` to get a `Bridge`. Let me know if you agree!

Since the `Bridge` is the central entrypoint of this API I also re-exported this at the crate level, so we can write `hueclient::Bridge` instead of of `hueclient::bridge::Bridge` everywhere.

When I was looking at the error handling I also noticed the parse function which tries to match several possible response formats (because the people at Philips think its necessary to stick single responses in an array for some reason). This can more easily be done using the `serde(untagged)` annotation. I wanted to make a separate pull request for this, but I'd already done it before you mentioned your preference for smaller PR. If you want, I can rip this out and make a separate PR.

Lastly I also added docs to the things I touched, so that the next person who looks at the code has that benefit. Let me know what you think!