### PR TITLE
Add group and scene support

### DIFF
--- a/src/bin/hue_get_all_groups.rs
+++ b/src/bin/hue_get_all_groups.rs
@@ -1,0 +1,35 @@
+extern crate hueclient;
+use std::env;
+
+#[allow(dead_code)]
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("usage : {:?} <username>", args[0]);
+        return;
+    }
+    let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
+    match bridge.get_all_groups() {
+        Ok(groups) => {
+            println!("id name                 on    bri   hue sat temp  x      y");
+            for ref l in groups.iter() {
+                println!(
+                    "{:2} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
+                    l.id,
+                    l.group.name,
+                    if l.group.state.all_on { "all on" } else if l.group.state.any_on { "some on"} else { "all off" },
+                    if l.group.action.bri.is_some() {l.group.action.bri.unwrap()} else {0},
+                    if l.group.action.hue.is_some() {l.group.action.hue.unwrap()} else {0},
+                    if l.group.action.sat.is_some() {l.group.action.sat.unwrap()} else {0},
+                    if l.group.action.ct.is_some() {l.group.action.ct.map(|k| if k != 0 { 1000000u32 / (k as u32) } else { 0 }).unwrap()} else {0},
+                    if l.group.action.xy.is_some() {l.group.action.xy.unwrap().0} else {0.0},
+                    if l.group.action.xy.is_some() {l.group.action.xy.unwrap().1} else {0.0},
+                );
+            }
+        }
+        Err(err) => {
+            println!("Error: {:?}", err);
+            ::std::process::exit(2)
+        }
+    }
+}

--- a/src/bin/hue_get_all_scenes.rs
+++ b/src/bin/hue_get_all_scenes.rs
@@ -1,0 +1,28 @@
+extern crate hueclient;
+use std::env;
+
+#[allow(dead_code)]
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("usage : {:?} <username>", args[0]);
+        return;
+    }
+    let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
+    match bridge.get_all_scenes() {
+        Ok(scenes) => {
+            println!("id name");
+            for ref l in scenes.iter() {
+                println!(
+                    "{:2} {:40}",
+                    l.id,
+                    l.scene.name,
+                );
+            }
+        }
+        Err(err) => {
+            println!("Error: {}", err);
+            ::std::process::exit(2)
+        }
+    }
+}

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -8,20 +8,20 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
         println!(
-            "usage : {:?} <username> <light_id>,<light_id>,... on|off|[bri]:[hue]:[sat]|[ct]MK:[bri]|[w]K:[bri]|[RR][GG][BB]:[bri]|[x,y]:[bri] [transition_time]",
+            "usage : {:?} <username> <group_id>,<group_id>,... on|off|[bri]:[hue]:[sat]|[ct]MK:[bri]|[w]K:[bri]|[RR][GG][BB]:[bri]|[x,y]:[bri] [transition_time]",
             args[0]
         );
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    let ref lights: Vec<usize> = args[2]
+    let ref groups: Vec<usize> = args[2]
         .split(",")
         .map(|s| s.parse::<usize>().unwrap())
         .collect();
     let parsed = hueclient::parse_command(args);
 
-    println!("lights: {:?}", lights);
-    for l in lights.iter() {
+    println!("groups: {:?}", groups);
+    for l in groups.iter() {
         println!("{:?}", bridge.set_light_state(*l, &parsed));
         std::thread::sleep(::std::time::Duration::from_millis(50))
     }

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -22,7 +22,7 @@ fn main() {
 
     println!("groups: {:?}", groups);
     for l in groups.iter() {
-        println!("{:?}", bridge.set_light_state(*l, &parsed));
+        println!("{:?}", bridge.set_group_state(*l, &parsed));
         std::thread::sleep(::std::time::Duration::from_millis(50))
     }
 }

--- a/src/bin/hue_set_scene.rs
+++ b/src/bin/hue_set_scene.rs
@@ -1,0 +1,21 @@
+extern crate hueclient;
+use std::env;
+
+#[allow(dead_code)]
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        println!("usage : {:?} <username> <scene>", args[0]);
+        return;
+    }
+    let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
+    match bridge.set_scene(args[2].to_string()) {
+        Ok(result) => {
+            println!("scene: {}, {}", args[2], result)
+        }
+        Err(err) => {
+            println!("Error: {}", err);
+            ::std::process::exit(2)
+        }
+    }
+}

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -53,6 +53,23 @@ pub struct IdentifiedLight {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Scene {
+    pub name: String,
+    pub r#type: String,
+    pub lights: Vec<String>,
+    pub owner: String,
+    pub recycle: bool,
+    pub locked: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct IdentifiedScene {
+    pub id: String,
+    pub scene: Scene,
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandLight {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<bool>,
@@ -70,6 +87,8 @@ pub struct CommandLight {
     pub transitiontime: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alert: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scene: Option<String>,
 }
 
 impl Default for CommandLight {
@@ -83,6 +102,7 @@ impl Default for CommandLight {
             ct: None,
             xy: None,
             alert: None,
+            scene: None,
         }
     }
 }
@@ -133,6 +153,12 @@ impl CommandLight {
     pub fn alert(self) -> CommandLight {
         CommandLight {
             alert: Some("select".into()),
+            ..self
+        }
+    }
+    pub fn scene(self, s: String) -> CommandLight {
+        CommandLight {
+            scene: Some(s),
             ..self
         }
     }
@@ -319,6 +345,16 @@ impl Bridge {
         Ok(lights)
     }
 
+    /// Returns a vector of all groups that are registered at this `Bridge`, sorted by their id's.
+    /// This function returns an error if `bridge.username` is `None`.
+    /// ### Example
+    /// ```rust
+    /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
+    ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
+    /// for group in &bridge.get_all_groups().unwrap() {
+    ///     println!("{:?}", group);
+    /// }
+    /// ``
     pub fn get_all_groups(&self) -> crate::Result<Vec<IdentifiedGroup>> {
         let url = format!("http://{}/api/{}/groups", self.ip, self.username);
         println!("{}", url);
@@ -334,6 +370,49 @@ impl Bridge {
         Ok(groups)
     }
 
+    /// Returns a vector of all scenes that are registered at this `Bridge`, sorted by their id's.
+    /// This function returns an error if `bridge.username` is `None`.
+    /// ### Example
+    /// ```rust
+    /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
+    ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
+    /// for scene in &bridge.get_all_scenes().unwrap() {
+    ///     println!("{:?}", scene);
+    /// }
+    /// ``
+    pub fn get_all_scenes(&self) -> crate::Result<Vec<IdentifiedScene>> {
+        let url = format!("http://{}/api/{}/scenes", self.ip, self.username);
+        println!("{}", url);
+        type Resp = BridgeResponse<HashMap<String, Scene>>;
+        let resp: Resp = self.client.get(&url).send()?.json()?;
+        let mut scenes = vec![];
+        for (k, scene) in resp.get()? {
+            scenes.push(IdentifiedScene { id:k, scene:scene });
+        }
+        scenes.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(scenes)
+    }
+
+    pub fn set_scene(&self, scene: String) -> crate::Result<Value> {
+        let url = format!(
+            "http://{}/api/{}/groups/0/action",
+            self.ip, self.username
+        );
+        let command = CommandLight::default().scene(scene);
+        let resp: BridgeResponse<Value> =
+            self.client.put(&url).json(&command).send()?.json()?;
+        resp.get()
+    }
+
+    pub fn set_group_state(&self, group: usize, command: &CommandLight) -> crate::Result<Value> {
+        let url = format!(
+            "http://{}/api/{}/groups/{}/action",
+            self.ip, self.username, group
+        );
+        let resp: BridgeResponse<Value> =
+            self.client.put(&url).json(command).send()?.json()?;
+        resp.get()
+    }
 
     pub fn set_light_state(&self, light: usize, command: &CommandLight) -> crate::Result<Value> {
         let url = format!(

--- a/src/command_parser.rs
+++ b/src/command_parser.rs
@@ -1,0 +1,102 @@
+
+use crate::CommandLight;
+use regex::Regex;
+
+pub fn parse_command(args: Vec<String>) -> CommandLight {
+    let re_triplet = Regex::new("([0-9]{0,3}):([0-9]{0,5}):([0-9]{0,3})").unwrap();
+    let re_mired = Regex::new("([0-9]{0,4})MK:([0-9]{0,5})").unwrap();
+    let re_kelvin = Regex::new("([0-9]{4,4})K:([0-9]{0,5})").unwrap();
+    let re_xy = Regex::new("(0\\.[0-9]+),(0\\.[0-9]+)(:([0-9]{0,5}))?").unwrap();
+    let re_rrggbb = Regex::new("([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})").unwrap();
+
+    let ref command = args[3];
+    let mut parsed = match &command[..] {
+        "on" => CommandLight::default().on(),
+        "off" => CommandLight::default().off(),
+        _ if re_triplet.is_match(&command) => {
+            let caps = re_triplet.captures(&command).unwrap();
+            let mut command = CommandLight::default().on();
+            command.bri = caps.get(1).and_then(|s| s.as_str().parse::<u8>().ok());
+            command.hue = caps.get(2).and_then(|s| s.as_str().parse::<u16>().ok());
+            command.sat = caps.get(3).and_then(|s| s.as_str().parse::<u8>().ok());
+            command
+        }
+        _ if re_mired.is_match(&command) => {
+            let caps = re_mired.captures(&command).unwrap();
+            let mut command = CommandLight::default().on();
+            command.ct = caps.get(1).and_then(|s| s.as_str().parse::<u16>().ok());
+            command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
+            command.sat = Some(254);
+            command
+        }
+        _ if re_kelvin.is_match(&command) => {
+            let caps = re_kelvin.captures(&command).unwrap();
+            let mut command = CommandLight::default().on();
+            command.ct = caps.get(1).and_then(|s| {
+                s.as_str().parse::<u32>().ok().map(
+                    |k| (1000000u32 / k) as u16,
+                )
+            });
+            command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
+            command.sat = Some(254);
+            command
+        }
+        _ if re_rrggbb.is_match(&command) => {
+            let caps = re_rrggbb.captures(&command).unwrap();
+            let mut command = CommandLight::default().on();
+            let rgb: Vec<u8> = [caps.get(1), caps.get(2), caps.get(3)]
+                .iter()
+                .map(|s| u8::from_str_radix(s.unwrap().as_str(), 16).unwrap())
+                .collect();
+            let hsv = rgb_to_hsv(rgb[0], rgb[1], rgb[2]);
+            println!("{:?}", hsv);
+            command.hue = Some((hsv.0 * 65535f64) as u16);
+            command.sat = Some((hsv.1 * 255f64) as u8);
+            command.bri = Some((hsv.2 * 255f64) as u8);
+            command
+        }
+        _ if re_xy.is_match(&command) => {
+            let caps = re_xy.captures(&command).unwrap();
+            dbg!(&caps);
+            let mut command = CommandLight::default().on();
+            let x = caps.get(1).unwrap().as_str().parse::<f32>().unwrap();
+            let y = caps.get(2).unwrap().as_str().parse::<f32>().unwrap();
+            command.xy = Some((x,y));
+            if let Some(bri) = caps.get(4) {
+                command.bri = Some(bri.as_str().parse::<u8>().unwrap());
+            }
+            command
+        }
+        _ => panic!("can not understand command {:?}", command),
+    };
+    if args.len() == 5 {
+        parsed.transitiontime = args[4].parse::<u16>().ok();
+    }
+    parsed
+}
+
+
+fn rgb_to_hsv(r: u8, g: u8, b: u8) -> (f64, f64, f64) {
+    let r = r as f64 / 255f64;
+    let g = g as f64 / 255f64;
+    let b = b as f64 / 255f64;
+    let max = r.max(g.max(b));
+    let min = r.min(g.min(b));
+
+    if max == min {
+        (0f64, 0f64, max)
+    } else {
+        let d = max - min;
+        let s = d / max;
+        let h = if max == r {
+            (g - b) / d + (if g < b { 6f64 } else { 0f64 })
+        } else if max == g {
+            (b - r) / d + 2f64
+        } else {
+            (r - g) / d + 4f64
+        };
+        (h / 6f64, s, max)
+    }
+}
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,5 +77,7 @@ pub type Result<T> = std::result::Result<T, HueError>;
 
 mod bridge;
 mod disco;
+mod command_parser;
 
 pub use bridge::*;
+pub use command_parser::*;


### PR DESCRIPTION
This PR adds a few commands to manipulate groups and scenes:

- refactor the command parser to be extracted for lights and groups
- add `hue_get_all_groups`, `hue_get_all_scenes`, ` hue_set_group_state`, `hue_set_scene`

This seems to be enough for basic group/scene usage.

What could be better:

- support for join between groups and scenes
