### PR TITLE
Remove printing of URL to groups and scenes endpoints

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -355,7 +355,6 @@ impl Bridge {
     /// ```
     pub fn get_all_groups(&self) -> crate::Result<Vec<IdentifiedGroup>> {
         let url = format!("http://{}/api/{}/groups", self.ip, self.username);
-        println!("{}", url);
         type Resp = BridgeResponse<HashMap<String, Group>>;
         let resp: Resp = self.client.get(&url).send()?.json()?;
         let mut groups = vec![];
@@ -380,7 +379,6 @@ impl Bridge {
     /// ```
     pub fn get_all_scenes(&self) -> crate::Result<Vec<IdentifiedScene>> {
         let url = format!("http://{}/api/{}/scenes", self.ip, self.username);
-        println!("{}", url);
         type Resp = BridgeResponse<HashMap<String, Scene>>;
         let resp: Resp = self.client.get(&url).send()?.json()?;
         let mut scenes = vec![];


### PR DESCRIPTION
This PR removes the `println!` calls in `get_all_groups()` and
`get_all_scenes()` that prints the Hue Bridge endpoints, including the secret
username.
