### PR TITLE
Use V2 API, move to async client, add events interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ repository = "http://github.com/kali/hue.rs"
 readme = "README.md"
 license = "WTFPL"
 keywords = [ "Philips", "hue", "light", "bulb" ]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-thiserror = "1.0.20"
+thiserror = "2.0.6"
 regex = "1.3"
-reqwest = { version = "0.10", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
+reqwest = { version = "0.12.9", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"
-ssdp-probe = "0.2"
 futures-util = "0.3.17"
 futures = "0.3.17"
 mdns = "3.0.0"
 async-std = "1.12.0"
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ futures = "0.3.17"
 mdns = "3.0.0"
 async-std = "1.12.0"
 log = "0.4"
+pretty_env_logger = { version = "0.5.0", optional = true }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2021"
 thiserror = "2.0.6"
 regex = "1.3"
 reqwest = { version = "0.12.9", features = [ "blocking", "json", "rustls-tls" ], default-features = false}
+reqwest-eventsource = "0.6.0"
+tokio = { version = "1.42.0", features = ["rt", "rt-multi-thread", "macros"] }
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"
 futures-util = "0.3.17"

--- a/src/bin/hue_discover_bridge.rs
+++ b/src/bin/hue_discover_bridge.rs
@@ -2,7 +2,8 @@ extern crate hueclient;
 use hueclient::Bridge;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 

--- a/src/bin/hue_discover_bridge.rs
+++ b/src/bin/hue_discover_bridge.rs
@@ -3,6 +3,9 @@ use hueclient::Bridge;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let bridge = Bridge::discover().unwrap();
     println!("Hue bridge found: {:?}", bridge);
 }

--- a/src/bin/hue_event_stream.rs
+++ b/src/bin/hue_event_stream.rs
@@ -1,0 +1,29 @@
+extern crate hueclient;
+use std::env;
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
+    log::info!("Starting hue_event_stream");
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("usage : {:?} <username>", args[0]);
+        return;
+    }
+    let bridge = hueclient::Bridge::discover().unwrap().with_user(args[1].to_string());
+
+    println!("got bridge");
+
+    match bridge.events() {
+        Ok(events) => {
+            events.for_each(|event| async move {
+                println!("{:?}", event);
+            }).await
+        }
+        Err(e) => { println!("Error: {}", e);  }
+    }
+}

--- a/src/bin/hue_get_all_groups.rs
+++ b/src/bin/hue_get_all_groups.rs
@@ -12,56 +12,54 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    match bridge.get_all_groups() {
-        Ok(groups) => {
-            println!("id name                 on    bri   hue sat temp  x      y");
-            for  l in groups.iter() {
+    println!("Rooms");
+    match bridge.resolve_all_rooms() {
+        Ok(rooms) => {
+            println!("id                                   name                 on");
+            for  r in rooms.iter() {
                 println!(
-                    "{:2} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
-                    l.id,
-                    l.group.name,
-                    if l.group.state.all_on {
+                    "{:2} {:20} {:5}",
+                    r.id,
+                    r.metadata.name,
+                    if r.children.iter().all(|l| l.on.on) {
                         "all on"
-                    } else if l.group.state.any_on {
+                    } else if r.children.iter().any(|l| l.on.on) {
                         "some on"
                     } else {
                         "all off"
                     },
-                    if l.group.action.bri.is_some() {
-                        l.group.action.bri.unwrap()
+                );
+                for service in &r.services {
+                    println!("  service: {} {}", service.rid, service.rtype);
+                }
+            }
+        }
+        Err(err) => {
+            log::error!("Error: {err:#?}");
+            println!("Error: {err}");
+            ::std::process::exit(2)
+        }
+    }
+    println!("Zones");
+    match bridge.resolve_all_zones() {
+        Ok(rooms) => {
+            println!("id                                   name                 on");
+            for  r in rooms.iter() {
+                println!(
+                    "{:2} {:20} {:5}",
+                    r.id,
+                    r.metadata.name,
+                    if r.children.iter().all(|l| l.on.on) {
+                        "all on"
+                    } else if r.children.iter().any(|l| l.on.on) {
+                        "some on"
                     } else {
-                        0
-                    },
-                    if l.group.action.hue.is_some() {
-                        l.group.action.hue.unwrap()
-                    } else {
-                        0
-                    },
-                    if l.group.action.sat.is_some() {
-                        l.group.action.sat.unwrap()
-                    } else {
-                        0
-                    },
-                    if l.group.action.ct.is_some() {
-                        l.group
-                            .action
-                            .ct
-                            .map(|k| if k != 0 { 1000000u32 / (k as u32) } else { 0 })
-                            .unwrap()
-                    } else {
-                        0
-                    },
-                    if l.group.action.xy.is_some() {
-                        l.group.action.xy.unwrap().0
-                    } else {
-                        0.0
-                    },
-                    if l.group.action.xy.is_some() {
-                        l.group.action.xy.unwrap().1
-                    } else {
-                        0.0
+                        "all off"
                     },
                 );
+                for service in &r.services {
+                    println!("  service: {} {}", service.rid, service.rtype);
+                }
             }
         }
         Err(err) => {

--- a/src/bin/hue_get_all_groups.rs
+++ b/src/bin/hue_get_all_groups.rs
@@ -2,7 +2,8 @@ extern crate hueclient;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -13,7 +14,7 @@ fn main() {
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     println!("Rooms");
-    match bridge.resolve_all_rooms() {
+    match bridge.resolve_all_rooms().await {
         Ok(rooms) => {
             println!("id                                   name                 on");
             for  r in rooms.iter() {
@@ -41,7 +42,7 @@ fn main() {
         }
     }
     println!("Zones");
-    match bridge.resolve_all_zones() {
+    match bridge.resolve_all_zones().await {
         Ok(rooms) => {
             println!("id                                   name                 on");
             for  r in rooms.iter() {

--- a/src/bin/hue_get_all_groups.rs
+++ b/src/bin/hue_get_all_groups.rs
@@ -12,7 +12,7 @@ fn main() {
     match bridge.get_all_groups() {
         Ok(groups) => {
             println!("id name                 on    bri   hue sat temp  x      y");
-            for ref l in groups.iter() {
+            for  l in groups.iter() {
                 println!(
                     "{:2} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
                     l.id,

--- a/src/bin/hue_get_all_groups.rs
+++ b/src/bin/hue_get_all_groups.rs
@@ -3,6 +3,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("usage : {:?} <username>", args[0]);
@@ -62,7 +65,8 @@ fn main() {
             }
         }
         Err(err) => {
-            println!("Error: {:?}", err);
+            log::error!("Error: {err:#?}");
+            println!("Error: {err}");
             ::std::process::exit(2)
         }
     }

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -2,7 +2,8 @@ extern crate hueclient;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -12,7 +13,7 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    match bridge.get_all_lights() {
+    match bridge.get_all_lights().await {
         Ok(lights) => {
             println!("id                                   name                 on    bri   hue sat temp  x      y");
             for l in lights.iter() {

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -12,7 +12,7 @@ fn main() {
     match bridge.get_all_lights() {
         Ok(lights) => {
             println!("id name                 on    bri   hue sat temp  x      y");
-            for ref l in lights.iter() {
+            for l in lights.iter() {
                 println!(
                     "{:2} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
                     l.id,

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -14,47 +14,30 @@ fn main() {
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     match bridge.get_all_lights() {
         Ok(lights) => {
-            println!("id name                 on    bri   hue sat temp  x      y");
+            println!("id                                   name                 on    bri   hue sat temp  x      y");
             for l in lights.iter() {
                 println!(
-                    "{:2} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
+                    "{} {:20} {:5} {:3} {:5} {:3} {:4}K {:4} {:4}",
                     l.id,
-                    l.light.name,
-                    if l.light.state.on { "on" } else { "off" },
-                    if l.light.state.bri.is_some() {
-                        l.light.state.bri.unwrap()
-                    } else {
-                        0
-                    },
-                    if l.light.state.hue.is_some() {
-                        l.light.state.hue.unwrap()
-                    } else {
-                        0
-                    },
-                    if l.light.state.sat.is_some() {
-                        l.light.state.sat.unwrap()
-                    } else {
-                        0
-                    },
-                    if l.light.state.ct.is_some() {
-                        l.light
-                            .state
-                            .ct
-                            .map(|k| if k != 0 { 1000000u32 / (k as u32) } else { 0 })
-                            .unwrap()
-                    } else {
-                        0
-                    },
-                    if l.light.state.xy.is_some() {
-                        l.light.state.xy.unwrap().0
-                    } else {
-                        0.0
-                    },
-                    if l.light.state.xy.is_some() {
-                        l.light.state.xy.unwrap().1
-                    } else {
-                        0.0
-                    },
+                    l.metadata.name,
+                    if l.on.on { "on" } else { "off" },
+                    l.dimming.as_ref().map(|d| d.brightness).unwrap_or(0.0),
+                    0, // hue
+                    0, // sat
+                    l.color_temperature
+                        .as_ref()
+                        .map(|ct| if let Some(mirek) = ct.mirek {
+                            if mirek != 0 {
+                                1000000u32 / (mirek as u32)
+                            } else {
+                                0
+                            }
+                        } else {
+                            0
+                        })
+                        .unwrap_or(0),
+                    l.color.as_ref().map(|color| color.xy.x).unwrap_or(0.0),
+                    l.color.as_ref().map(|color| color.xy.y).unwrap_or(0.0),
                 );
             }
         }

--- a/src/bin/hue_get_all_lights.rs
+++ b/src/bin/hue_get_all_lights.rs
@@ -3,6 +3,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("usage : {:?} <username>", args[0]);
@@ -56,7 +59,8 @@ fn main() {
             }
         }
         Err(err) => {
-            println!("Error: {}", err);
+            log::error!("Error: {err:#?}");
+            println!("Error: {err}");
             ::std::process::exit(2)
         }
     }

--- a/src/bin/hue_get_all_scenes.rs
+++ b/src/bin/hue_get_all_scenes.rs
@@ -14,9 +14,9 @@ fn main() {
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     match bridge.get_all_scenes() {
         Ok(scenes) => {
-            println!("id name");
+            println!("id                                   name");
             for l in scenes.iter() {
-                println!("{:2} {:40}", l.id, l.scene.name,);
+                println!("{:2} {:40}", l.id, l.metadata.name,);
             }
         }
         Err(err) => {

--- a/src/bin/hue_get_all_scenes.rs
+++ b/src/bin/hue_get_all_scenes.rs
@@ -3,6 +3,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         println!("usage : {:?} <username>", args[0]);
@@ -17,7 +20,8 @@ fn main() {
             }
         }
         Err(err) => {
-            println!("Error: {}", err);
+            log::error!("Error: {err:#?}");
+            println!("Error: {err}");
             ::std::process::exit(2)
         }
     }

--- a/src/bin/hue_get_all_scenes.rs
+++ b/src/bin/hue_get_all_scenes.rs
@@ -2,7 +2,8 @@ extern crate hueclient;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main() {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -12,7 +13,7 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    match bridge.get_all_scenes() {
+    match bridge.get_all_scenes().await {
         Ok(scenes) => {
             println!("id                                   name");
             for l in scenes.iter() {

--- a/src/bin/hue_get_all_scenes.rs
+++ b/src/bin/hue_get_all_scenes.rs
@@ -12,7 +12,7 @@ fn main() {
     match bridge.get_all_scenes() {
         Ok(scenes) => {
             println!("id name");
-            for ref l in scenes.iter() {
+            for l in scenes.iter() {
                 println!("{:2} {:40}", l.id, l.scene.name,);
             }
         }

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -15,11 +15,11 @@ fn main() {
         let bridge = hueclient::Bridge::discover_required();
         println!("posting user {:?} in {:?}", args[1], bridge);
         loop {
-            let r = bridge.clone().register_user(&args[1]);
+            let r = bridge.clone().register_application(&args[1]);
             match r {
                 Ok(r) => {
                     eprint!("done: ");
-                    println!("{}", r.username);
+                    println!("{}", r.application_key);
                     break;
                 }
                 Err(HueError::BridgeError { code: 101, .. }) => {

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -5,6 +5,9 @@ use std::env;
 #[allow(while_true)]
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         println!("usage : {:?} <devicetype>", args[0]);
@@ -23,7 +26,7 @@ fn main() {
                     println!("Push the bridge button");
                     std::thread::sleep(::std::time::Duration::from_secs(5));
                 }
-                Err(e) => panic!("error {:?}", e),
+                Err(e) => panic!("error {e}"),
             }
         }
     }

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -4,7 +4,8 @@ use std::env;
 
 #[allow(while_true)]
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -15,7 +16,7 @@ fn main() {
         let bridge = hueclient::Bridge::discover_required();
         println!("posting user {:?} in {:?}", args[1], bridge);
         loop {
-            let r = bridge.clone().register_application(&args[1]);
+            let r = bridge.clone().register_application(&args[1]).await;
             match r {
                 Ok(r) => {
                     eprint!("done: ");

--- a/src/bin/hue_register_user.rs
+++ b/src/bin/hue_register_user.rs
@@ -19,7 +19,7 @@ fn main() {
                     println!("{}", r.username);
                     break;
                 }
-                Err(HueError::BridgeError { code, .. }) if code == 101 => {
+                Err(HueError::BridgeError { code: 101, .. }) => {
                     println!("Push the bridge button");
                     std::thread::sleep(::std::time::Duration::from_secs(5));
                 }

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -5,6 +5,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
         println!(

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -14,7 +14,7 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    let ref groups: Vec<usize> = args[2]
+    let groups: Vec<usize> = args[2]
         .split(",")
         .map(|s| s.parse::<usize>().unwrap())
         .collect();

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -17,9 +17,9 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    let groups: Vec<usize> = args[2]
+    let group_ids = args[2].clone();
+    let groups: Vec<&str> = group_ids
         .split(",")
-        .map(|s| s.parse::<usize>().unwrap())
         .collect();
     let parsed = hueclient::parse_command(args);
 

--- a/src/bin/hue_set_group_state.rs
+++ b/src/bin/hue_set_group_state.rs
@@ -4,7 +4,8 @@ extern crate regex;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -25,7 +26,7 @@ fn main() {
 
     println!("groups: {:?}", groups);
     for l in groups.iter() {
-        println!("{:?}", bridge.set_group_state(*l, &parsed));
+        println!("{:?}", bridge.set_group_state(*l, &parsed).await);
         std::thread::sleep(::std::time::Duration::from_millis(50))
     }
 }

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -14,7 +14,7 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    let ref lights: Vec<usize> = args[2]
+    let lights: Vec<usize> = args[2]
         .split(",")
         .map(|s| s.parse::<usize>().unwrap())
         .collect();

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -5,6 +5,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
         println!(

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -17,9 +17,10 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    let lights: Vec<usize> = args[2]
+
+    let light_ids = args[2].clone();
+    let lights: Vec<&str> = light_ids
         .split(",")
-        .map(|s| s.parse::<usize>().unwrap())
         .collect();
     let parsed = hueclient::parse_command(args);
 

--- a/src/bin/hue_set_light_state.rs
+++ b/src/bin/hue_set_light_state.rs
@@ -4,7 +4,8 @@ extern crate regex;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main()  {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -26,7 +27,7 @@ fn main() {
 
     println!("lights: {:?}", lights);
     for l in lights.iter() {
-        println!("{:?}", bridge.set_light_state(*l, &parsed));
+        println!("{:?}", bridge.set_light_state(*l, &parsed).await);
         std::thread::sleep(::std::time::Duration::from_millis(50))
     }
 }

--- a/src/bin/hue_set_scene.rs
+++ b/src/bin/hue_set_scene.rs
@@ -14,7 +14,7 @@ fn main() {
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
     match bridge.set_scene(args[2].to_string()) {
         Ok(result) => {
-            println!("scene: {}, {}", args[2], result)
+            println!("scene: {}, {:?}", args[2], result)
         }
         Err(err) => {
             log::error!("Error: {err:#?}");

--- a/src/bin/hue_set_scene.rs
+++ b/src/bin/hue_set_scene.rs
@@ -3,6 +3,9 @@ use std::env;
 
 #[allow(dead_code)]
 fn main() {
+    #[cfg(feature = "pretty_env_logger")]
+    pretty_env_logger::init_custom_env("HUE_LOG");
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
         println!("usage : {:?} <username> <scene>", args[0]);
@@ -14,7 +17,8 @@ fn main() {
             println!("scene: {}, {}", args[2], result)
         }
         Err(err) => {
-            println!("Error: {}", err);
+            log::error!("Error: {err:#?}");
+            println!("Error: {err}");
             ::std::process::exit(2)
         }
     }

--- a/src/bin/hue_set_scene.rs
+++ b/src/bin/hue_set_scene.rs
@@ -2,7 +2,8 @@ extern crate hueclient;
 use std::env;
 
 #[allow(dead_code)]
-fn main() {
+#[tokio::main]
+async fn main() {
     #[cfg(feature = "pretty_env_logger")]
     pretty_env_logger::init_custom_env("HUE_LOG");
 
@@ -12,7 +13,7 @@ fn main() {
         return;
     }
     let bridge = hueclient::Bridge::discover_required().with_user(args[1].to_string());
-    match bridge.set_scene(args[2].to_string()) {
+    match bridge.set_scene(args[2].to_string()).await {
         Ok(result) => {
             println!("scene: {}, {:?}", args[2], result)
         }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -67,7 +67,7 @@ pub struct IdentifiedScene {
     pub scene: Scene,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommandLight {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<bool>,
@@ -87,22 +87,6 @@ pub struct CommandLight {
     pub alert: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scene: Option<String>,
-}
-
-impl Default for CommandLight {
-    fn default() -> CommandLight {
-        CommandLight {
-            on: None,
-            bri: None,
-            hue: None,
-            sat: None,
-            transitiontime: None,
-            ct: None,
-            xy: None,
-            alert: None,
-            scene: None,
-        }
-    }
 }
 
 impl CommandLight {
@@ -167,7 +151,7 @@ impl CommandLight {
 pub struct UnauthBridge {
     /// The IP-address of the bridge.
     pub ip: std::net::IpAddr,
-    pub(self) client: reqwest::blocking::Client,
+    client: reqwest::blocking::Client,
 }
 
 impl UnauthBridge {
@@ -227,7 +211,7 @@ pub struct Bridge {
     pub ip: std::net::IpAddr,
     /// This is the username of the currently logged in user.
     pub username: String,
-    pub(self) client: reqwest::blocking::Client,
+    client: reqwest::blocking::Client,
 }
 
 impl Bridge {
@@ -385,7 +369,7 @@ impl Bridge {
         for (k, scene) in resp.get()? {
             scenes.push(IdentifiedScene {
                 id: k,
-                scene: scene,
+                scene,
             });
         }
         scenes.sort_by(|a, b| a.id.cmp(&b.id));
@@ -452,6 +436,7 @@ struct BridgeError {
 
 #[derive(Debug, serde::Deserialize)]
 struct BridgeErrorInner {
+    #[allow(dead_code)]
     address: String,
     description: String,
     r#type: usize,

--- a/src/command_parser.rs
+++ b/src/command_parser.rs
@@ -8,28 +8,28 @@ pub fn parse_command(args: Vec<String>) -> CommandLight {
     let re_xy = Regex::new("(0\\.[0-9]+),(0\\.[0-9]+)(:([0-9]{0,5}))?").unwrap();
     let re_rrggbb = Regex::new("([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})").unwrap();
 
-    let ref command = args[3];
+    let command = &args[3];
     let mut parsed = match &command[..] {
         "on" => CommandLight::default().on(),
         "off" => CommandLight::default().off(),
-        _ if re_triplet.is_match(&command) => {
-            let caps = re_triplet.captures(&command).unwrap();
+        _ if re_triplet.is_match(command) => {
+            let caps = re_triplet.captures(command).unwrap();
             let mut command = CommandLight::default().on();
             command.bri = caps.get(1).and_then(|s| s.as_str().parse::<u8>().ok());
             command.hue = caps.get(2).and_then(|s| s.as_str().parse::<u16>().ok());
             command.sat = caps.get(3).and_then(|s| s.as_str().parse::<u8>().ok());
             command
         }
-        _ if re_mired.is_match(&command) => {
-            let caps = re_mired.captures(&command).unwrap();
+        _ if re_mired.is_match(command) => {
+            let caps = re_mired.captures(command).unwrap();
             let mut command = CommandLight::default().on();
             command.ct = caps.get(1).and_then(|s| s.as_str().parse::<u16>().ok());
             command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
             command.sat = Some(254);
             command
         }
-        _ if re_kelvin.is_match(&command) => {
-            let caps = re_kelvin.captures(&command).unwrap();
+        _ if re_kelvin.is_match(command) => {
+            let caps = re_kelvin.captures(command).unwrap();
             let mut command = CommandLight::default().on();
             command.ct = caps.get(1).and_then(|s| {
                 s.as_str()
@@ -41,8 +41,8 @@ pub fn parse_command(args: Vec<String>) -> CommandLight {
             command.sat = Some(254);
             command
         }
-        _ if re_rrggbb.is_match(&command) => {
-            let caps = re_rrggbb.captures(&command).unwrap();
+        _ if re_rrggbb.is_match(command) => {
+            let caps = re_rrggbb.captures(command).unwrap();
             let mut command = CommandLight::default().on();
             let rgb: Vec<u8> = [caps.get(1), caps.get(2), caps.get(3)]
                 .iter()
@@ -55,8 +55,8 @@ pub fn parse_command(args: Vec<String>) -> CommandLight {
             command.bri = Some((hsv.2 * 255f64) as u8);
             command
         }
-        _ if re_xy.is_match(&command) => {
-            let caps = re_xy.captures(&command).unwrap();
+        _ if re_xy.is_match(command) => {
+            let caps = re_xy.captures(command).unwrap();
             dbg!(&caps);
             let mut command = CommandLight::default().on();
             let x = caps.get(1).unwrap().as_str().parse::<f32>().unwrap();

--- a/src/command_parser.rs
+++ b/src/command_parser.rs
@@ -1,4 +1,4 @@
-use crate::CommandLight;
+use crate::{CommandLight};
 use regex::Regex;
 
 pub fn parse_command(args: Vec<String>) -> CommandLight {
@@ -13,68 +13,83 @@ pub fn parse_command(args: Vec<String>) -> CommandLight {
         "on" => CommandLight::default().on(),
         "off" => CommandLight::default().off(),
         _ if re_triplet.is_match(command) => {
-            let caps = re_triplet.captures(command).unwrap();
-            let mut command = CommandLight::default().on();
-            command.bri = caps.get(1).and_then(|s| s.as_str().parse::<u8>().ok());
-            command.hue = caps.get(2).and_then(|s| s.as_str().parse::<u16>().ok());
-            command.sat = caps.get(3).and_then(|s| s.as_str().parse::<u8>().ok());
-            command
+            log::debug!("HSV triplet: {command}");
+            todo!("HSV support");
+            // let caps = re_triplet.captures(command).unwrap();
+            // let mut command = LightPut::default().on();
+            // command.bri = caps.get(1).and_then(|s| s.as_str().parse::<u8>().ok());
+            // command.hue = caps.get(2).and_then(|s| s.as_str().parse::<u16>().ok());
+            // command.sat = caps.get(3).and_then(|s| s.as_str().parse::<u8>().ok());
+            // command
         }
         _ if re_mired.is_match(command) => {
+            log::debug!("Mired: {command}");
             let caps = re_mired.captures(command).unwrap();
             let mut command = CommandLight::default().on();
-            command.ct = caps.get(1).and_then(|s| s.as_str().parse::<u16>().ok());
-            command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
-            command.sat = Some(254);
+            if let Some(mirek) = caps.get(1).and_then(|s| s.as_str().parse::<u16>().ok()) {
+                command= command.with_mirek(mirek)
+            }
+            if let Some(brightness) = caps.get(2).and_then(|s| s.as_str().parse::<f32>().ok()) {
+                command = command.with_brightness(brightness)
+            }
             command
         }
         _ if re_kelvin.is_match(command) => {
+            log::debug!("Kelvin: {command}");
             let caps = re_kelvin.captures(command).unwrap();
             let mut command = CommandLight::default().on();
-            command.ct = caps.get(1).and_then(|s| {
+            if let Some(mirek) =  caps.get(1).and_then(|s| {
                 s.as_str()
                     .parse::<u32>()
                     .ok()
                     .map(|k| (1000000u32 / k) as u16)
-            });
-            command.bri = caps.get(2).and_then(|s| s.as_str().parse::<u8>().ok());
-            command.sat = Some(254);
+            }) {
+                command = command.with_mirek(mirek)
+            }
+            if let Some(brightness) = caps.get(2).and_then(|s| s.as_str().parse::<f32>().ok()) {
+                command = command.with_brightness(brightness)
+            }
             command
         }
         _ if re_rrggbb.is_match(command) => {
-            let caps = re_rrggbb.captures(command).unwrap();
-            let mut command = CommandLight::default().on();
-            let rgb: Vec<u8> = [caps.get(1), caps.get(2), caps.get(3)]
-                .iter()
-                .map(|s| u8::from_str_radix(s.unwrap().as_str(), 16).unwrap())
-                .collect();
-            let hsv = rgb_to_hsv(rgb[0], rgb[1], rgb[2]);
-            println!("{:?}", hsv);
-            command.hue = Some((hsv.0 * 65535f64) as u16);
-            command.sat = Some((hsv.1 * 255f64) as u8);
-            command.bri = Some((hsv.2 * 255f64) as u8);
-            command
+            log::debug!("RRGGBB: {command}");
+            todo!("HSV support");
+            // let caps = re_rrggbb.captures(command).unwrap();
+            // let mut command = LightPut::default().on();
+            // let rgb: Vec<u8> = [caps.get(1), caps.get(2), caps.get(3)]
+            //     .iter()
+            //     .map(|s| u8::from_str_radix(s.unwrap().as_str(), 16).unwrap())
+            //     .collect();
+            // let hsv = rgb_to_hsv(rgb[0], rgb[1], rgb[2]);
+            // println!("{:?}", hsv);
+            // command.hue = Some((hsv.0 * 65535f64) as u16);
+            // command.sat = Some((hsv.1 * 255f64) as u8);
+            // command.bri = Some((hsv.2 * 255f64) as u8);
+            // command
         }
         _ if re_xy.is_match(command) => {
+            log::debug!("XY: {command}");
             let caps = re_xy.captures(command).unwrap();
-            dbg!(&caps);
             let mut command = CommandLight::default().on();
             let x = caps.get(1).unwrap().as_str().parse::<f32>().unwrap();
             let y = caps.get(2).unwrap().as_str().parse::<f32>().unwrap();
-            command.xy = Some((x, y));
-            if let Some(bri) = caps.get(4) {
-                command.bri = Some(bri.as_str().parse::<u8>().unwrap());
+            command = command.with_xy(x, y);
+            if let Some(bri) = caps.get(4).and_then(|s| s.as_str().parse::<f32>().ok())  {
+                command = command.with_brightness(bri);
             }
             command
         }
         _ => panic!("can not understand command {:?}", command),
     };
     if args.len() == 5 {
-        parsed.transitiontime = args[4].parse::<u16>().ok();
+        if let Some(ms) = args[4].parse::<u32>().ok() {
+            parsed = parsed.with_transition_time(ms);
+        }
     }
     parsed
 }
 
+#[allow(dead_code)]
 fn rgb_to_hsv(r: u8, g: u8, b: u8) -> (f64, f64, f64) {
     let r = r as f64 / 255f64;
     let g = g as f64 / 255f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,6 @@ pub enum HueError {
     /// Returned when discovery.meethue.com returns an invalid IP-address.
     #[error("An error occurred while parsing an address")]
     AddrParse(#[from] std::net::AddrParseError),
-    /// Returned when the SSDP probe fails to scan the current network for a bridge.
-    #[error("An error occurred during SSDP discovery")]
-    SSDP(#[from] ssdp_probe::SsdpProbeError),
     /// Returned when the Bridge returns a response that does not confirm to the API spec.
     #[error("A protocol error occurred: {}", msg)]
     ProtocolError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub enum HueError {
     /// Returned when a network error occurs.
     #[error("An error occurred while performing an HTTP request")]
     Reqwest(#[from] reqwest::Error),
+    #[error("An error occurred while creating an event source")]
+    ReqwestEventSource(#[from] reqwest_eventsource::CannotCloneRequestError),
     /// Returned on a JSON failure, which will usually be a problem with deserializing the bridge
     /// response.
     #[error("An error occurred while manipulating JSON")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@
 //! ### Initial Setup
 //! ```no_run
 //! let bridge = hueclient::Bridge::discover_required()
-//!     .register_user("mycomputer") // Press the bridge before running this
+//!     .register_application("mycomputer") // Press the bridge before running this
 //!     .unwrap();
-//! println!("the username was {}", bridge.username); // handy for later
+//! println!("the username was {}", bridge.application_key); // handy for later
 //! ```
 //! ### Second run
 //! ```no_run
@@ -22,7 +22,7 @@
 //! #   .with_user(USERNAME);
 //! let cmd = hueclient::CommandLight::default().off();
 //! for light in &bridge.get_all_lights().unwrap() {
-//!     bridge.set_light_state(light.id, &cmd).unwrap();
+//!     bridge.set_light_state(&light.id, &cmd).unwrap();
 //! }
 //! ```
 
@@ -52,6 +52,11 @@ pub enum HueError {
         code: usize,
         /// An error message describing the failure.
         msg: String,
+    },
+    #[error("The bridge reported an error: {}", description)]
+    BridgeErrorV2 {
+        /// An error message describing the failure.
+        description: String,
     },
     /// Returned when discovering a bridge in the local network fails.
     #[error("A discovery error occurred: {}", msg)]


### PR DESCRIPTION
Hello ! 

This is a huge refactor of the crate, in order to bring it to 2025, here is an overview of what as done:

- update dependencies and use edition 2021
- use HTTPS to connect to the bridge (I had to enable the `danger_accept_invalid_certs` as some older bridge still use self signed certificates, the [hue documentation](https://developers.meethue.com/develop/application-design-guidance/using-https/) says we show check that the common name in the certificate matches the bridge id, we should probably do that at some point)
- added some logging, all the binaries now have a `pretty_env_logger` feature that checks for the `HUE_LOG` env var and uses it to setup the logger, this is quite useful for debugging
- use the clip V2 api, this is the new way to interact with the hue bridges, this means quite a few changes
  - ids are now uuids instead of ints
  - groups are now split into rooms and zones (there is still a function to act on a "grouped_light" that can be either of those)
  - the hue/saturation values are not directly available in the api, only XY gamut values are easily retrievable, conversion code to support the old hsv and rrggbb modes in the hue_set_light_state and hue_set_group_state should be writable but was not done here
 - add API to retrieve the eventstream provided with the new v2 api
 - moved to the async request client: using the async client was a requirement to be able to provide the eventstream api, and it would be easy to provide a blocking client using simple `tokio::block_on` this poses a problem to some users

Given the move to the V2 api and the use of async, this properly breaks pretty much all apis the crate exposed. The output of the various binary also changed a bit (no more hue/sat values + room and scene split in get_groups). We should update the version in consequence the next time a release of this crate is done