### PR TITLE
Properly resolve lights that are part of room

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ async-std = "1.12.0"
 log = "0.4"
 pretty_env_logger = { version = "0.5.0", optional = true }
 
+[dev-dependencies]
+tokio-test = "0.4.4"

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -285,10 +285,12 @@ impl UnauthBridge {
     /// shortly before running this function.
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let mut bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4]);
-    /// let auth_bridge = bridge.register_application("mylaptop").unwrap();
+    /// let auth_bridge = bridge.register_application("mylaptop").await.unwrap();
     /// let key = auth_bridge.application_key;
     /// // now this key can be stored and reused
+    /// # })
     /// ```
     pub async fn register_application(self, name: &str) -> crate::Result<Bridge> {
         #[derive(Serialize)]
@@ -425,11 +427,14 @@ impl Bridge {
     /// shortly before running this function.
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///     .register_application("mylaptop")
+    ///     .await
     ///     .unwrap();
     /// // now this username d can be stored and reused
     /// println!("the password was {}", bridge.application_key);
+    /// # })
     /// ```
     pub async fn register_application(self, name: &str) -> crate::Result<Bridge> {
         #[derive(Serialize)]
@@ -460,11 +465,13 @@ impl Bridge {
     ///
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
-    /// for device in &bridge.get_all_devices().unwrap() {
+    /// for device in &bridge.get_all_devices().await.unwrap() {
     ///     println!("{:?}", device);
     /// }
+    /// # })
     /// ```
     pub async fn get_all_devices(&self) -> crate::Result<Vec<Device>> {
         let url = format!("https://{}/clip/v2/resource/device", self.ip);
@@ -484,11 +491,13 @@ impl Bridge {
     ///
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
-    /// for light in &bridge.get_all_lights().unwrap() {
+    /// for light in &bridge.get_all_lights().await.unwrap() {
     ///     println!("{:?}", light);
     /// }
+    /// # })
     /// ```
     pub async fn get_all_lights(&self) -> crate::Result<Vec<Light>> {
         let url = format!("https://{}/clip/v2/resource/light", self.ip);
@@ -513,11 +522,13 @@ impl Bridge {
     /// This function returns an error if `bridge.username` is `None`.
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
-    /// for room in &bridge.get_all_rooms().unwrap() {
+    /// for room in &bridge.get_all_rooms().await.unwrap() {
     ///     println!("{:?}", room);
     /// }
+    /// # })
     /// ```
     pub async fn get_all_rooms(&self) -> crate::Result<Vec<Room>> {
         let url = format!("https://{}/clip/v2/resource/room", self.ip);
@@ -562,11 +573,13 @@ impl Bridge {
     /// This function returns an error if `bridge.username` is `None`.
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
-    /// for zone in &bridge.get_all_zones().unwrap() {
+    /// for zone in &bridge.get_all_zones().await.unwrap() {
     ///     println!("{:?}", zone);
     /// }
+    /// # })
     /// ```
     pub async fn get_all_zones(&self) -> crate::Result<Vec<Zone>> {
         let url = format!("https://{}/clip/v2/resource/zone", self.ip);
@@ -601,11 +614,13 @@ impl Bridge {
     /// This function returns an error if `bridge.username` is `None`.
     /// ### Example
     /// ```no_run
+    /// # tokio_test::block_on(async {
     /// let bridge = hueclient::Bridge::for_ip([192u8, 168, 0, 4])
     ///    .with_user("rVV05G0i52vQMMLn6BK3dpr0F3uDiqtDjPLPK2uj");
-    /// for scene in &bridge.get_all_scenes().unwrap() {
+    /// for scene in &bridge.get_all_scenes().await.unwrap() {
     ///     println!("{:?}", scene);
     /// }
+    /// # })
     /// ```
     pub async fn get_all_scenes(&self) -> crate::Result<Vec<Scene>> {
         let url = format!("https://{}/clip/v2/resource/scene", self.ip);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@
 //! A short overview of the most common use cases of this library.
 //! ### Initial Setup
 //! ```no_run
+//! # tokio_test::block_on(async {
 //! let bridge = hueclient::Bridge::discover_required()
 //!     .register_application("mycomputer") // Press the bridge before running this
+//!     .await
 //!     .unwrap();
 //! println!("the username was {}", bridge.application_key); // handy for later
+//! # })
 //! ```
 //! ### Second run
 //! ```no_run
@@ -17,13 +20,15 @@
 //! ```
 //! ### Good night
 //! ```no_run
+//! # tokio_test::block_on(async {
 //! # const USERNAME: &str = "the username that was generated in the previous example";
 //! # let bridge = hueclient::Bridge::discover_required()
 //! #   .with_user(USERNAME);
 //! let cmd = hueclient::CommandLight::default().off();
-//! for light in &bridge.get_all_lights().unwrap() {
-//!     bridge.set_light_state(&light.id, &cmd).unwrap();
+//! for light in &bridge.get_all_lights().await.unwrap() {
+//!     bridge.set_light_state(&light.id, &cmd).await.unwrap();
 //! }
+//! # })
 //! ```
 
 /// Represents any of the ways that usage of this library may fail.


### PR DESCRIPTION
Hue zones are meant to contain only lights and therefore return lights as their children.

However rooms can be used to group other device types, and return devices for their children. Therefore we need to follow the device ids returned in a room's children, and extract lights based on the light services declared by these devices.