### PR TITLE
let's go mit/apache2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Rust library for Philips Hue lights"
 homepage = "http://github.com/kali/hue.rs"
 repository = "http://github.com/kali/hue.rs"
 readme = "README.md"
-license = "WTFPL"
+license = "MIT OR Apache-2.0"
 keywords = [ "Philips", "hue", "light", "bulb" ]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,28 @@
  - list lights with their state
  - simple actions on lights (on, off, bri/hue/sat, transition time)
  - simple CLI utils for docs and tests :)
+
+## Licencing
+
+Originally, this crate being a week-end one-shot hack, I released it under WTFPL license. My intent was
+to allow anybody to use this software under the terms of a very permissive license, while minimizing the
+licensing discussions and arguments.
+
+A couple of years later, it appears that the strategy failed it second objective as  WTFPL regularly
+raise the kind of issues it was meant to avoid.
+
+So, this software is now released under the following licensinc scheme:
+
+Apache 2.0/MIT/WTFPL
+
+All original work licensed under either of
+
+    Apache License, Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+    MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+    WTFPL (https://en.wikipedia.org/wiki/WTFPL)
+
+at your option.
+
+Additionally, in order to minimize the discussion around WTFPL wording, only "MIT OR Apache-2.0" will be
+tagged in Cargo.toml. The intent here is that WTFPL does not appear on its own or in combination in
+license tracking systems.


### PR DESCRIPTION
We are changing the licencing scheme!

WTFPL was supposed to prevent licensing discussion, but it obviously did not work, so here we go again.

I think what I propose to do is compliant with both the WTFPL terms and intent, and acceptable from a pragmatic licence tracking point of view.

I will leave this PR open for a week or so. If, and only if you're a hue.rs contributor, please raise any concern you may have. Please, please, I beg you, don't make this a big thing just for the sake of it.